### PR TITLE
use syslog-stdout instead of busybox-syslogd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,18 @@
+# build syslog-stdout in a separate container (pinned to a known-good commit
+# corresponding to the 1.1.1 release)
+FROM golang:1-alpine AS builder
+RUN apk add --no-cache git musl-dev gcc && \
+  git clone https://github.com/timonier/syslog-stdout /go/src/github.com/timonier/syslog-stdout && \
+  git -C /go/src/github.com/timonier/syslog-stdout checkout 026971e18bbc8c0ce289abb3c5da1bbf3e2de523 && \
+  go build -ldflags '-s -w -linkmode external -extldflags -static' -o /usr/bin/syslog-stdout github.com/timonier/syslog-stdout/src
+
+################################################################################
+
 FROM debian:stretch-slim
 
 ENV PATH=/opt/venv/bin:$PATH
 
+COPY --from=builder /usr/bin/syslog-stdout /usr/bin/
 COPY . /opt/swift
 
 # give --build-arg BUILD_MODE=sap to install components required by required by

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 # install dependencies
 apt-get update
 apt-get dist-upgrade -y
-DEPENDS="netbase ca-certificates curl python virtualenv sudo rsync gettext liberasurecode1 libffi6 libssl1.1 busybox-syslogd netcat"
+DEPENDS="netbase ca-certificates curl python virtualenv sudo rsync gettext liberasurecode1 libffi6 libssl1.1 netcat"
 MAKEDEPENDS="git virtualenv build-essential python-dev liberasurecode-dev libffi-dev libssl-dev"
 apt-get install -y --no-install-recommends ${DEPENDS} ${MAKEDEPENDS}
 


### PR DESCRIPTION
The busybox-syslogd cannot handle messages beyond ~1 KB, so esp. stacktraces are cut off which is quite annoying. My testing shows that syslog-stdout handles large messages correctly at least until 8 KB.

@reimannf Have a look. There will be a companion PR in helm-charts. I will start testing in staging on Monday if ok with you.