### PR TITLE
Adding libjerasure2 libisal2

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 # install dependencies
 apt-get update
 apt-get dist-upgrade -y
-DEPENDS="netbase ca-certificates curl python virtualenv sudo rsync gettext liberasurecode1 libffi6 libssl1.1 netcat procps lsof iproute2"
+DEPENDS="netbase ca-certificates curl python virtualenv sudo rsync gettext liberasurecode1 libjerasure2 libisal2 libffi6 libssl1.1 netcat procps lsof iproute2"
 MAKEDEPENDS="git virtualenv build-essential python-dev liberasurecode-dev libffi-dev libssl-dev"
 apt-get install -y --no-install-recommends ${DEPENDS} ${MAKEDEPENDS}
 


### PR DESCRIPTION
Prevent complains about missing shared libs

```
Nov 16 07:55:06 storage0 user.err Nov 16 07:55:06 liberasurecode[22396]: liberasurecode_instance_create: dynamic linking error libJerasure.so.2: cannot open shared object file: No such file or directory
Nov 16 07:55:06 storage0 user.err Nov 16 07:55:06 liberasurecode[22396]: liberasurecode_instance_create: dynamic linking error libisal.so.2: cannot open shared object file: No such file or directory
Nov 16 07:55:06 storage0 user.err Nov 16 07:55:06 liberasurecode[22396]: liberasurecode_instance_create: dynamic linking error libshss.so.1: cannot open shared object file: No such file or directory
```

libshss warning should be fixed in higher PyCELib