### PR TITLE
internal-client.conf needed by binarary swift-account-ratelimit

### DIFF
--- a/docker/bin/swift-start
+++ b/docker/bin/swift-start
@@ -54,6 +54,7 @@ function process_config {
             get_swift_configs proxy-server.conf dispersion.conf
             ;;
         account-caretaker-*)
+            get_swift_configs internal-client.conf
             ;;
         account-*)
             get_swift_configs account-server.conf


### PR DESCRIPTION
https://github.com/sapcc/swift-account-caretaker/blob/master/bin/swift-account-ratelimit