### PR TITLE
update openstack-watcher-middleware.git to 1.0.30

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -50,7 +50,7 @@ if [ "${BUILD_MODE}" = sap ]; then
     git+https://github.com/sapcc/swift-health-statsd.git \
     git+https://github.com/sapcc/swift-addons.git \
     git+https://github.com/sapcc/swift-sentry.git \
-    git+https://github.com/sapcc/openstack-watcher-middleware.git@1.0.17
+    git+https://github.com/sapcc/openstack-watcher-middleware.git@1.0.30
 
   # apply keystonemiddleware patch
   (


### PR DESCRIPTION
notable new features: pass project name, project domain name, domain name via environ. useful to whitelist certain projects by name instead of uuid