### PR TITLE
Cherry Pick: cname_lookup: Work with dnspython 2.0+ 

### DIFF
--- a/swift/common/middleware/cname_lookup.py
+++ b/swift/common/middleware/cname_lookup.py
@@ -59,7 +59,7 @@ def lookup_cname(domain, resolver):  # pragma: no cover
     try:
         answer = resolver.query(domain, 'CNAME').rrset
         ttl = answer.ttl
-        result = answer.items[0].to_text()
+        result = list(answer.items)[0].to_text()
         result = result.rstrip('.')
         return ttl, result
     except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):


### PR DESCRIPTION
provided eventlet is new enough to be compatible.
Change-Id: Ie823091f93e76a4d658db7b1499f99d5faefcd81

We have `haproxy` redispatches because of `500` responses coming from:

```
File "/opt/venv/lib/python3.8/site-packages/swift/common/middleware/cname_lookup.py", line 62, in lookup_cname#012    result = answer.items[0].to_text()#012KeyError: 0
```