### PR TITLE
Fixing python dependency error on module pkg_resources

### DIFF
--- a/docker-sap/build.sh
+++ b/docker-sap/build.sh
@@ -101,12 +101,12 @@ git -C /opt/swift fetch origin
 # setup virtualenv and install Swift there
 python3.11 -m venv /opt/venv/
 set +ux; source /opt/venv/bin/activate; set -ux
-python3.11 -m pip install --upgrade pip setuptools wheel
+python3.11 -m pip install --upgrade pip 'setuptools<81' wheel
 pip_install() {
   pip --no-cache-dir install --upgrade "$@"
 }
 pip_install pip
-pip_install setuptools wheel
+pip_install 'setuptools<81' wheel
 pip_install --no-compile -c /root/upper-constraints.txt \
   /opt/swift/ \
   keystonemiddleware \

--- a/docker-sap/build.sh
+++ b/docker-sap/build.sh
@@ -69,9 +69,7 @@ if [ "${BUILD_MODE}" = sap ]; then
   sed -i '/requests===/c\requests===2.32.4' /root/upper-constraints.txt
 
 #
-# setuptools patch
-# CVE-2024-6345
-  rm -rf /usr/local/lib/python3.11/site-packages/setuptools*
+
 
 #
 # idna patch
@@ -103,6 +101,7 @@ git -C /opt/swift fetch origin
 # setup virtualenv and install Swift there
 python3.11 -m venv /opt/venv/
 set +ux; source /opt/venv/bin/activate; set -ux
+python3.11 -m pip install --upgrade pip setuptools wheel
 pip_install() {
   pip --no-cache-dir install --upgrade "$@"
 }


### PR DESCRIPTION
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/opt/venv/lib/python3.11/site-packages/keystonemiddleware/auth_token/__init__.py", line 235, in <module>
    from keystonemiddleware._common import config
  File "/opt/venv/lib/python3.11/site-packages/keystonemiddleware/_common/config.py", line 13, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
Feb 15 12:14:52.778845 swift-proxy-cluster-3-g7zz8 authpriv.info Feb 15 12:14:52 sudo: pam_unix(sudo:session): session closed for user swift